### PR TITLE
Migration to the new pass manager in optimization routines

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -160,6 +160,10 @@ if(ENABLE_CLANG_AS_LIB)
       ${SRC_PREFIX}/CompilerImpl/ClangLibCompiler.cpp
       ${SRC_PREFIX}/CompilerImpl/ClangLLVM/FileLogDiagnosticConsumer.cpp
       ${SRC_PREFIX}/CompilerImpl/ClangLLVM/LLVMInstanceManager.cpp)
+  if(LLVM_VERSION_MAJOR GREATER_EQUAL 15)
+    set(VC_LIB_SRC ${VC_LIB_SRC}
+                   ${SRC_PREFIX}/CompilerImpl/ClangLLVM/NewPMDriver.cpp)
+  endif(LLVM_VERSION_MAJOR GREATER_EQUAL 15)
 
   set(VC_LIB_HDR2 ${VC_LIB_HDR2} ${VC_LIB_HDR_PREFIX2}/JITCompiler.hpp
                   ${VC_LIB_HDR_PREFIX2}/ClangLibCompiler.hpp)
@@ -169,7 +173,7 @@ if(ENABLE_CLANG_AS_LIB)
   )
 
   set(VC_LIB_HDR3
-      ${VC_LIB_HDR_PREFIX3}/OptUtils.hpp
+      ${VC_LIB_HDR_PREFIX3}/OptUtils.hpp ${VC_LIB_HDR_PREFIX3}/NewPMDriver.h
       ${VC_LIB_HDR_PREFIX3}/FileLogDiagnosticConsumer.hpp
       ${VC_LIB_HDR_PREFIX3}/LLVMInstanceManager.hpp)
 endif(ENABLE_CLANG_AS_LIB)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -173,7 +173,8 @@ if(ENABLE_CLANG_AS_LIB)
   )
 
   set(VC_LIB_HDR3
-      ${VC_LIB_HDR_PREFIX3}/OptUtils.hpp ${VC_LIB_HDR_PREFIX3}/NewPMDriver.h
+      ${VC_LIB_HDR_PREFIX3}/OptUtils.hpp
+      ${VC_LIB_HDR_PREFIX3}/NewPMDriver.h
       ${VC_LIB_HDR_PREFIX3}/FileLogDiagnosticConsumer.hpp
       ${VC_LIB_HDR_PREFIX3}/LLVMInstanceManager.hpp)
 endif(ENABLE_CLANG_AS_LIB)

--- a/Test.cpp
+++ b/Test.cpp
@@ -167,7 +167,7 @@ int main(int argc, char const *argv[]) {
   });
 #else
   builder.setOptOptions({
-      vc::Option("mem2reg", "-passes='defaultO3,mem2reg'"),
+      vc::Option("optimization passes", "-passes=","'default<O3>,mem2reg'"),
   });
 #endif
   vc::version_ptr_t v4 = builder.build();

--- a/TestJit.cpp
+++ b/TestJit.cpp
@@ -107,7 +107,7 @@ int main(int argc, char const *argv[]) {
   });
 #else
   builder.setOptOptions({
-      vc::Option("mem2reg", "-passes='defaultO3,mem2reg'"),
+      vc::Option("optimization passes", "-passes=","'default<O3>,mem2reg'"),
   });
 #endif
   std::cout << "Building version.." << std::endl;

--- a/include/versioningCompiler/CompilerImpl/ClangLLVM/LLVMInstanceManager.hpp
+++ b/include/versioningCompiler/CompilerImpl/ClangLLVM/LLVMInstanceManager.hpp
@@ -20,6 +20,8 @@
  *
  * You should have received a copy of the GNU Lesser General Public License
  * along with libVersioningCompiler. If not, see <http://www.gnu.org/licenses/>
+ * 
+ * This utility uses a modified version of the opt.cpp file's main function. Its main job is to initialize the opt related functions.
  */
 #ifndef LIB_VERSIONING_COMPILER_CLANG_LLVM_LLVM_INSTANCE_MANAGER
 #define LIB_VERSIONING_COMPILER_CLANG_LLVM_LLVM_INSTANCE_MANAGER

--- a/include/versioningCompiler/CompilerImpl/ClangLLVM/LLVMInstanceManager.hpp
+++ b/include/versioningCompiler/CompilerImpl/ClangLLVM/LLVMInstanceManager.hpp
@@ -21,7 +21,8 @@
  * You should have received a copy of the GNU Lesser General Public License
  * along with libVersioningCompiler. If not, see <http://www.gnu.org/licenses/>
  * 
- * This utility uses a modified version of the opt.cpp file's main function. Its main job is to initialize the opt related functions.
+ * This utility uses a modified version of the `opt.cpp` file's main function.
+ * Its main job is to initialize the opt related functions.
  */
 #ifndef LIB_VERSIONING_COMPILER_CLANG_LLVM_LLVM_INSTANCE_MANAGER
 #define LIB_VERSIONING_COMPILER_CLANG_LLVM_LLVM_INSTANCE_MANAGER

--- a/include/versioningCompiler/CompilerImpl/ClangLLVM/NewPMDriver.h
+++ b/include/versioningCompiler/CompilerImpl/ClangLLVM/NewPMDriver.h
@@ -16,6 +16,7 @@
 /// opt.cpp.
 ///
 //===----------------------------------------------------------------------===//
+// Added macro comments to make it work from LLVM 13 to LLVM 16
 
 #ifndef LIB_VERSIONING_COMPILER_CLANG_LLVM_TOOLS_OPT_NEWPMDRIVER_H
 #define LIB_VERSIONING_COMPILER_CLANG_LLVM_TOOLS_OPT_NEWPMDRIVER_H
@@ -27,9 +28,7 @@
 namespace llvm {
 class StringRef;
 class Module;
-#if LLVM_VERSION_MAJOR > 14
 class PassPlugin;
-#endif
 class TargetMachine;
 class ToolOutputFile;
 class TargetLibraryInfoImpl;
@@ -48,7 +47,7 @@ enum OutputKind {
   OK_OutputBitcode,
   OK_OutputThinLTOBitcode,
 };
-enum VerifierKind { VK_NoVerifier, VK_VerifyInAndOut, VK_VerifyEachPass };
+enum VerifierKind { VK_NoVerifier, VK_VerifyOut, VK_VerifyEachPass };
 enum PGOKind { NoPGO, InstrGen, InstrUse, SampleUse };
 enum CSPGOKind { NoCSPGO, CSInstrGen, CSInstrUse };
 } // namespace opt_tool
@@ -64,27 +63,16 @@ void printPasses(raw_ostream &OS);
 ///
 /// ThinLTOLinkOut is only used when OK is OK_OutputThinLTOBitcode, and can be
 /// nullptr.
-#if LLVM_VERSION_MAJOR > 14
 bool runPassPipeline(StringRef Arg0, Module &M, TargetMachine *TM,
                      TargetLibraryInfoImpl *TLII, ToolOutputFile *Out,
                      ToolOutputFile *ThinLinkOut, ToolOutputFile *OptRemarkFile,
-                     StringRef PassPipeline, ArrayRef<StringRef> PassInfos,
-                     ArrayRef<PassPlugin> PassPlugins, opt_tool::OutputKind OK,
-                     opt_tool::VerifierKind VK,
-                     bool ShouldPreserveAssemblyUseListOrder,
-                     bool ShouldPreserveBitcodeUseListOrder,
-                     bool EmitSummaryIndex, bool EmitModuleHash,
-                     bool EnableDebugify, bool VerifyDIPreserve);
-#else
-bool runPassPipeline(StringRef Arg0, Module &M, TargetMachine *TM,
-                     TargetLibraryInfoImpl *TLII, ToolOutputFile *Out,
-                     ToolOutputFile *ThinLinkOut, ToolOutputFile *OptRemarkFile,
-                     StringRef PassPipeline, ArrayRef<StringRef> PassInfos,
+                     StringRef PassPipeline, ArrayRef<PassPlugin> PassPlugins,
                      opt_tool::OutputKind OK, opt_tool::VerifierKind VK,
                      bool ShouldPreserveAssemblyUseListOrder,
                      bool ShouldPreserveBitcodeUseListOrder,
                      bool EmitSummaryIndex, bool EmitModuleHash,
-                     bool EnableDebugify);
-#endif
+                     bool EnableDebugify, bool VerifyDIPreserve);
+                    
+
 } // namespace llvm
 #endif

--- a/include/versioningCompiler/CompilerImpl/ClangLLVM/NewPMDriver.h
+++ b/include/versioningCompiler/CompilerImpl/ClangLLVM/NewPMDriver.h
@@ -16,6 +16,7 @@
 /// opt.cpp.
 ///
 //===----------------------------------------------------------------------===//
+// This is a copy of the ``new" pass manager implementation in LLVM, with the following modifications
 // Added macro comments to make it work from LLVM 13 to LLVM 16
 
 #ifndef LIB_VERSIONING_COMPILER_CLANG_LLVM_TOOLS_OPT_NEWPMDRIVER_H

--- a/lib/CompilerImpl/ClangLLVM/LLVMInstanceManager.cpp
+++ b/lib/CompilerImpl/ClangLLVM/LLVMInstanceManager.cpp
@@ -62,6 +62,7 @@ std::shared_ptr<llvm::Triple> LLVMInstanceManager::getDefaultTriple() const {
 // ---------------------------------------------------------------------------
 // ----------------------------- initializeLLVM -----------------------------
 // ---------------------------------------------------------------------------
+// Most of this comes from the LLVM's opt.cpp's main function
 void LLVMInstanceManager::initializeLLVM() {
   llvm::InitializeAllTargetInfos();
   llvm::InitializeAllTargets();
@@ -97,6 +98,15 @@ void LLVMInstanceManager::initializeLLVM() {
   llvm::initializeTarget(passRegistry);
   // For codegen passes, only passes that do IR to IR transformation are
   // supported.
+#if LLVM_VERSION_MAJOR >= 16
+  llvm::initializeExpandLargeDivRemLegacyPassPass(passRegistry);
+  llvm::initializeExpandLargeFpConvertLegacyPassPass(passRegistry);
+#endif
+  llvm::initializeExpandMemCmpPassPass(passRegistry);
+  llvm::initializeScalarizeMaskedMemIntrinLegacyPassPass(passRegistry);
+#if LLVM_VERSION_MAJOR > 14
+  llvm::initializeSelectOptimizePass(passRegistry);
+#endif
   llvm::initializeCodeGenPreparePass(passRegistry);
   llvm::initializeAtomicExpandPass(passRegistry);
   llvm::initializeRewriteSymbolsLegacyPassPass(passRegistry);
@@ -106,12 +116,28 @@ void LLVMInstanceManager::initializeLLVM() {
   llvm::initializeSjLjEHPreparePass(passRegistry);
   llvm::initializePreISelIntrinsicLoweringLegacyPassPass(passRegistry);
   llvm::initializeGlobalMergePass(passRegistry);
+  llvm::initializeIndirectBrExpandPassPass(passRegistry);
+  llvm::initializeInterleavedLoadCombinePass(passRegistry);
   llvm::initializeInterleavedAccessPass(passRegistry);
 #if LLVM_VERSION_MAJOR < 15
   llvm::initializeEntryExitInstrumenterPass(passRegistry);
   llvm::initializePostInlineEntryExitInstrumenterPass(passRegistry);
 #endif
   llvm::initializeUnreachableBlockElimLegacyPassPass(passRegistry);
+  llvm::initializeExpandReductionsPass(passRegistry);
+  llvm::initializeExpandVectorPredicationPass(passRegistry);
+  llvm::initializeWasmEHPreparePass(passRegistry);
+  llvm::initializeWriteBitcodePassPass(passRegistry);
+  llvm::initializeHardwareLoopsPass(passRegistry);
+#if LLVM_VERSION_MAJOR < 16
+  llvm::initializeTypePromotionPass(passRegistry);
+#endif
+  llvm::initializeReplaceWithVeclibLegacyPass(passRegistry);
+#if LLVM_VERSION_MAJOR > 14  
+  llvm::initializeJMCInstrumenterPass(passRegistry);
+#endif  
+  llvm::initializeUnreachableBlockElimLegacyPassPass(passRegistry);
+
 
   // remember default target triple , not suitable for cross compiling
   // https://reviews.llvm.org/D34446

--- a/lib/CompilerImpl/ClangLLVM/NewPMDriver.cpp
+++ b/lib/CompilerImpl/ClangLLVM/NewPMDriver.cpp
@@ -1,0 +1,552 @@
+//===- NewPMDriver.cpp - Driver for opt with new PM -----------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+/// \file
+///
+/// This file is just a split of the code that logically belongs in opt.cpp but
+/// that includes the new pass manager headers.
+///
+//===----------------------------------------------------------------------===//
+// The section between macros had been added to allow cross compatibility with
+// older LLVM versions
+#include "versioningCompiler/CompilerImpl/ClangLLVM/NewPMDriver.h"
+#include "llvm/ADT/SmallVector.h"
+#include "llvm/ADT/StringRef.h"
+#include "llvm/Analysis/AliasAnalysis.h"
+#include "llvm/Analysis/CGSCCPassManager.h"
+#include "llvm/Analysis/TargetLibraryInfo.h"
+#include "llvm/Bitcode/BitcodeWriterPass.h"
+#include "llvm/Config/llvm-config.h"
+#include "llvm/IR/Dominators.h"
+#include "llvm/IR/LLVMContext.h"
+#include "llvm/IR/Module.h"
+#include "llvm/IR/PassManager.h"
+#include "llvm/IR/Verifier.h"
+#if LLVM_VERSION_MAJOR >= 16
+#include "llvm/IRPrinter/IRPrintingPasses.h"
+#endif
+#include "llvm/Passes/PassBuilder.h"
+#include "llvm/Passes/PassPlugin.h"
+#include "llvm/Passes/StandardInstrumentations.h"
+#include "llvm/Support/ErrorHandling.h"
+#include "llvm/Support/ToolOutputFile.h"
+#include "llvm/Support/raw_ostream.h"
+#include "llvm/Target/TargetMachine.h"
+#include "llvm/Transforms/IPO/ThinLTOBitcodeWriter.h"
+#include "llvm/Transforms/Instrumentation/AddressSanitizer.h"
+#include "llvm/Transforms/Scalar/LoopPassManager.h"
+#include "llvm/Transforms/Utils/Debugify.h"
+
+using namespace llvm;
+using namespace opt_tool;
+
+namespace llvm {
+cl::opt<bool> DebugifyEach(
+    "debugify-each",
+    cl::desc("Start each pass with debugify and end it with check-debugify"));
+
+cl::opt<std::string>
+    DebugifyExport("debugify-export",
+                   cl::desc("Export per-pass debugify statistics to this file"),
+                   cl::value_desc("filename"));
+
+cl::opt<bool> VerifyEachDebugInfoPreserve(
+    "verify-each-debuginfo-preserve",
+    cl::desc("Start each pass with collecting and end it with checking of "
+             "debug info preservation."));
+
+cl::opt<std::string> VerifyDIPreserveExport(
+    "verify-di-preserve-export",
+    cl::desc("Export debug info preservation failures into "
+             "specified (JSON) file (should be abs path as we use"
+             " append mode to insert new JSON objects)"),
+    cl::value_desc("filename"), cl::init(""));
+
+} // namespace llvm
+
+enum class DebugLogging { None, Normal, Verbose, Quiet };
+
+static cl::opt<DebugLogging> DebugPM(
+    "debug-pass-manager", cl::Hidden, cl::ValueOptional,
+    cl::desc("Print pass management debugging information"),
+    cl::init(DebugLogging::None),
+    cl::values(
+        clEnumValN(DebugLogging::Normal, "", ""),
+        clEnumValN(DebugLogging::Quiet, "quiet",
+                   "Skip printing info about analyses"),
+        clEnumValN(
+            DebugLogging::Verbose, "verbose",
+            "Print extra information about adaptors and pass managers")));
+
+// This flag specifies a textual description of the alias analysis pipeline to
+// use when querying for aliasing information. It only works in concert with
+// the "passes" flag above.
+static cl::opt<std::string>
+    AAPipeline("aa-pipeline",
+               cl::desc("A textual description of the alias analysis "
+                        "pipeline for handling managed aliasing queries"),
+               cl::Hidden, cl::init("default"));
+
+/// {{@ These options accept textual pipeline descriptions which will be
+/// inserted into default pipelines at the respective extension points
+static cl::opt<std::string> PeepholeEPPipeline(
+    "passes-ep-peephole",
+    cl::desc("A textual description of the function pass pipeline inserted at "
+             "the Peephole extension points into default pipelines"),
+    cl::Hidden);
+static cl::opt<std::string> LateLoopOptimizationsEPPipeline(
+    "passes-ep-late-loop-optimizations",
+    cl::desc(
+        "A textual description of the loop pass pipeline inserted at "
+        "the LateLoopOptimizations extension point into default pipelines"),
+    cl::Hidden);
+static cl::opt<std::string> LoopOptimizerEndEPPipeline(
+    "passes-ep-loop-optimizer-end",
+    cl::desc("A textual description of the loop pass pipeline inserted at "
+             "the LoopOptimizerEnd extension point into default pipelines"),
+    cl::Hidden);
+static cl::opt<std::string> ScalarOptimizerLateEPPipeline(
+    "passes-ep-scalar-optimizer-late",
+    cl::desc("A textual description of the function pass pipeline inserted at "
+             "the ScalarOptimizerLate extension point into default pipelines"),
+    cl::Hidden);
+static cl::opt<std::string> CGSCCOptimizerLateEPPipeline(
+    "passes-ep-cgscc-optimizer-late",
+    cl::desc("A textual description of the cgscc pass pipeline inserted at "
+             "the CGSCCOptimizerLate extension point into default pipelines"),
+    cl::Hidden);
+static cl::opt<std::string> VectorizerStartEPPipeline(
+    "passes-ep-vectorizer-start",
+    cl::desc("A textual description of the function pass pipeline inserted at "
+             "the VectorizerStart extension point into default pipelines"),
+    cl::Hidden);
+static cl::opt<std::string> PipelineStartEPPipeline(
+    "passes-ep-pipeline-start",
+    cl::desc("A textual description of the module pass pipeline inserted at "
+             "the PipelineStart extension point into default pipelines"),
+    cl::Hidden);
+static cl::opt<std::string> PipelineEarlySimplificationEPPipeline(
+    "passes-ep-pipeline-early-simplification",
+    cl::desc("A textual description of the module pass pipeline inserted at "
+             "the EarlySimplification extension point into default pipelines"),
+    cl::Hidden);
+static cl::opt<std::string> OptimizerEarlyEPPipeline(
+    "passes-ep-optimizer-early",
+    cl::desc("A textual description of the module pass pipeline inserted at "
+             "the OptimizerEarly extension point into default pipelines"),
+    cl::Hidden);
+static cl::opt<std::string> OptimizerLastEPPipeline(
+    "passes-ep-optimizer-last",
+    cl::desc("A textual description of the module pass pipeline inserted at "
+             "the OptimizerLast extension point into default pipelines"),
+    cl::Hidden);
+static cl::opt<std::string> FullLinkTimeOptimizationEarlyEPPipeline(
+    "passes-ep-full-link-time-optimization-early",
+    cl::desc("A textual description of the module pass pipeline inserted at "
+             "the FullLinkTimeOptimizationEarly extension point into default "
+             "pipelines"),
+    cl::Hidden);
+static cl::opt<std::string> FullLinkTimeOptimizationLastEPPipeline(
+    "passes-ep-full-link-time-optimization-last",
+    cl::desc("A textual description of the module pass pipeline inserted at "
+             "the FullLinkTimeOptimizationLast extension point into default "
+             "pipelines"),
+    cl::Hidden);
+/// @}}
+
+static cl::opt<bool> DisablePipelineVerification(
+    "disable-pipeline-verification",
+    cl::desc("Only has an effect when specified with -print-pipeline-passes. "
+             "Disables verifying that the textual pipeline generated by "
+             "-print-pipeline-passes can be used to create a pipeline."),
+    cl::Hidden);
+
+
+static cl::opt<PGOKind>
+    PGOKindFlag("pgo-kind", cl::init(NoPGO), cl::Hidden,
+                cl::desc("The kind of profile guided optimization"),
+                cl::values(clEnumValN(NoPGO, "nopgo", "Do not use PGO."),
+                           clEnumValN(InstrGen, "pgo-instr-gen-pipeline",
+                                      "Instrument the IR to generate profile."),
+                           clEnumValN(InstrUse, "pgo-instr-use-pipeline",
+                                      "Use instrumented profile to guide PGO."),
+                           clEnumValN(SampleUse, "pgo-sample-use-pipeline",
+                                      "Use sampled profile to guide PGO.")));
+static cl::opt<std::string>
+    ProfileFile("profile-file", cl::desc("Path to the profile."), cl::Hidden);
+
+static cl::opt<CSPGOKind> CSPGOKindFlag(
+    "cspgo-kind", cl::init(NoCSPGO), cl::Hidden,
+    cl::desc("The kind of context sensitive profile guided optimization"),
+    cl::values(
+        clEnumValN(NoCSPGO, "nocspgo", "Do not use CSPGO."),
+        clEnumValN(
+            CSInstrGen, "cspgo-instr-gen-pipeline",
+            "Instrument (context sensitive) the IR to generate profile."),
+        clEnumValN(
+            CSInstrUse, "cspgo-instr-use-pipeline",
+            "Use instrumented (context sensitive) profile to guide PGO.")));
+
+static cl::opt<std::string> CSProfileGenFile(
+    "cs-profilegen-file",
+    cl::desc("Path to the instrumented context sensitive profile."),
+    cl::Hidden);
+
+static cl::opt<std::string>
+    ProfileRemappingFile("profile-remapping-file",
+                         cl::desc("Path to the profile remapping file."),
+                         cl::Hidden);
+
+static cl::opt<bool> DebugInfoForProfiling(
+    "debug-info-for-profiling", cl::init(false), cl::Hidden,
+    cl::desc("Emit special debug info to enable PGO profile generation."));
+
+static cl::opt<bool> PseudoProbeForProfiling(
+    "pseudo-probe-for-profiling", cl::init(false), cl::Hidden,
+    cl::desc("Emit pseudo probes to enable PGO profile generation."));
+
+static cl::opt<bool> DisableLoopUnrolling(
+    "disable-loop-unrolling",
+    cl::desc("Disable loop unrolling in all relevant passes"), cl::init(false));
+
+namespace llvm {
+extern cl::opt<bool> PrintPipelinePasses;
+} // namespace llvm
+
+template <typename PassManagerT>
+bool tryParsePipelineText(PassBuilder &PB,
+                          const cl::opt<std::string> &PipelineOpt) {
+  if (PipelineOpt.empty())
+    return false;
+
+  // Verify the pipeline is parseable:
+  PassManagerT PM;
+  if (auto Err = PB.parsePassPipeline(PM, PipelineOpt)) {
+    errs() << "Could not parse -" << PipelineOpt.ArgStr
+           << " pipeline: " << toString(std::move(Err))
+           << "... I'm going to ignore it.\n";
+    return false;
+  }
+  return true;
+}
+
+/// If one of the EPPipeline command line options was given, register callbacks
+/// for parsing and inserting the given pipeline
+static void registerEPCallbacks(PassBuilder &PB) {
+  if (tryParsePipelineText<FunctionPassManager>(PB, PeepholeEPPipeline))
+    PB.registerPeepholeEPCallback(
+        [&PB](FunctionPassManager &PM, OptimizationLevel Level) {
+          ExitOnError Err("Unable to parse PeepholeEP pipeline: ");
+          Err(PB.parsePassPipeline(PM, PeepholeEPPipeline));
+        });
+  if (tryParsePipelineText<LoopPassManager>(PB,
+                                            LateLoopOptimizationsEPPipeline))
+    PB.registerLateLoopOptimizationsEPCallback(
+        [&PB](LoopPassManager &PM, OptimizationLevel Level) {
+          ExitOnError Err("Unable to parse LateLoopOptimizationsEP pipeline: ");
+          Err(PB.parsePassPipeline(PM, LateLoopOptimizationsEPPipeline));
+        });
+  if (tryParsePipelineText<LoopPassManager>(PB, LoopOptimizerEndEPPipeline))
+    PB.registerLoopOptimizerEndEPCallback(
+        [&PB](LoopPassManager &PM, OptimizationLevel Level) {
+          ExitOnError Err("Unable to parse LoopOptimizerEndEP pipeline: ");
+          Err(PB.parsePassPipeline(PM, LoopOptimizerEndEPPipeline));
+        });
+  if (tryParsePipelineText<FunctionPassManager>(PB,
+                                                ScalarOptimizerLateEPPipeline))
+    PB.registerScalarOptimizerLateEPCallback(
+        [&PB](FunctionPassManager &PM, OptimizationLevel Level) {
+          ExitOnError Err("Unable to parse ScalarOptimizerLateEP pipeline: ");
+          Err(PB.parsePassPipeline(PM, ScalarOptimizerLateEPPipeline));
+        });
+  if (tryParsePipelineText<CGSCCPassManager>(PB, CGSCCOptimizerLateEPPipeline))
+    PB.registerCGSCCOptimizerLateEPCallback(
+        [&PB](CGSCCPassManager &PM, OptimizationLevel Level) {
+          ExitOnError Err("Unable to parse CGSCCOptimizerLateEP pipeline: ");
+          Err(PB.parsePassPipeline(PM, CGSCCOptimizerLateEPPipeline));
+        });
+  if (tryParsePipelineText<FunctionPassManager>(PB, VectorizerStartEPPipeline))
+    PB.registerVectorizerStartEPCallback(
+        [&PB](FunctionPassManager &PM, OptimizationLevel Level) {
+          ExitOnError Err("Unable to parse VectorizerStartEP pipeline: ");
+          Err(PB.parsePassPipeline(PM, VectorizerStartEPPipeline));
+        });
+  if (tryParsePipelineText<ModulePassManager>(PB, PipelineStartEPPipeline))
+    PB.registerPipelineStartEPCallback(
+        [&PB](ModulePassManager &PM, OptimizationLevel) {
+          ExitOnError Err("Unable to parse PipelineStartEP pipeline: ");
+          Err(PB.parsePassPipeline(PM, PipelineStartEPPipeline));
+        });
+  if (tryParsePipelineText<ModulePassManager>(
+          PB, PipelineEarlySimplificationEPPipeline))
+    PB.registerPipelineEarlySimplificationEPCallback(
+        [&PB](ModulePassManager &PM, OptimizationLevel) {
+          ExitOnError Err("Unable to parse EarlySimplification pipeline: ");
+          Err(PB.parsePassPipeline(PM, PipelineEarlySimplificationEPPipeline));
+        });
+  if (tryParsePipelineText<ModulePassManager>(PB, OptimizerEarlyEPPipeline))
+    PB.registerOptimizerEarlyEPCallback(
+        [&PB](ModulePassManager &PM, OptimizationLevel) {
+          ExitOnError Err("Unable to parse OptimizerEarlyEP pipeline: ");
+          Err(PB.parsePassPipeline(PM, OptimizerEarlyEPPipeline));
+        });
+  if (tryParsePipelineText<ModulePassManager>(PB, OptimizerLastEPPipeline))
+    PB.registerOptimizerLastEPCallback(
+        [&PB](ModulePassManager &PM, OptimizationLevel) {
+          ExitOnError Err("Unable to parse OptimizerLastEP pipeline: ");
+          Err(PB.parsePassPipeline(PM, OptimizerLastEPPipeline));
+        });
+  if (tryParsePipelineText<ModulePassManager>(
+          PB, FullLinkTimeOptimizationEarlyEPPipeline))
+    PB.registerFullLinkTimeOptimizationEarlyEPCallback(
+        [&PB](ModulePassManager &PM, OptimizationLevel) {
+          ExitOnError Err(
+              "Unable to parse FullLinkTimeOptimizationEarlyEP pipeline: ");
+          Err(PB.parsePassPipeline(PM,
+                                   FullLinkTimeOptimizationEarlyEPPipeline));
+        });
+  if (tryParsePipelineText<ModulePassManager>(
+          PB, FullLinkTimeOptimizationLastEPPipeline))
+    PB.registerFullLinkTimeOptimizationLastEPCallback(
+        [&PB](ModulePassManager &PM, OptimizationLevel) {
+          ExitOnError Err(
+              "Unable to parse FullLinkTimeOptimizationLastEP pipeline: ");
+          Err(PB.parsePassPipeline(PM, FullLinkTimeOptimizationLastEPPipeline));
+        });
+}
+
+#define HANDLE_EXTENSION(Ext)                                                  \
+  llvm::PassPluginLibraryInfo get##Ext##PluginInfo();
+#include "llvm/Support/Extension.def"
+
+bool llvm::runPassPipeline(
+    StringRef Arg0, Module &M, TargetMachine *TM, TargetLibraryInfoImpl *TLII,
+    ToolOutputFile *Out, ToolOutputFile *ThinLTOLinkOut,
+    ToolOutputFile *OptRemarkFile, StringRef PassPipeline,
+    ArrayRef<PassPlugin> PassPlugins, OutputKind OK, VerifierKind VK,
+    bool ShouldPreserveAssemblyUseListOrder,
+    bool ShouldPreserveBitcodeUseListOrder, bool EmitSummaryIndex,
+    bool EmitModuleHash, bool EnableDebugify, bool VerifyDIPreserve) {
+  bool VerifyEachPass = VK == VK_VerifyEachPass;
+#if LLVM_VERSION_MAJOR < 16
+  Optional<PGOOptions> P;
+#else
+  std::optional<PGOOptions> P;
+#endif
+  switch (PGOKindFlag) {
+  case InstrGen:
+    P = PGOOptions(ProfileFile, "", "", PGOOptions::IRInstr);
+    break;
+  case InstrUse:
+    P = PGOOptions(ProfileFile, "", ProfileRemappingFile, PGOOptions::IRUse);
+    break;
+  case SampleUse:
+    P = PGOOptions(ProfileFile, "", ProfileRemappingFile,
+                   PGOOptions::SampleUse);
+    break;
+  case NoPGO:
+    if (DebugInfoForProfiling || PseudoProbeForProfiling)
+      P = PGOOptions("", "", "", PGOOptions::NoAction, PGOOptions::NoCSAction,
+                     DebugInfoForProfiling, PseudoProbeForProfiling);
+    else
+#if LLVM_VERSION_MAJOR >= 16
+      P = std::nullopt;
+#else
+      P = None;
+#endif
+  }
+  if (CSPGOKindFlag != NoCSPGO) {
+    if (P && (P->Action == PGOOptions::IRInstr ||
+              P->Action == PGOOptions::SampleUse)) {
+      errs() << "CSPGOKind cannot be used with IRInstr or SampleUse";
+      return false;
+    }
+    if (CSPGOKindFlag == CSInstrGen) {
+      if (CSProfileGenFile.empty()) {
+        errs() << "CSInstrGen needs to specify CSProfileGenFile";
+        return false;
+      }
+      if (P) {
+        P->CSAction = PGOOptions::CSIRInstr;
+        P->CSProfileGenFile = CSProfileGenFile;
+      } else
+        P = PGOOptions("", CSProfileGenFile, ProfileRemappingFile,
+                       PGOOptions::NoAction, PGOOptions::CSIRInstr);
+    } else /* CSPGOKindFlag == CSInstrUse */ {
+      if (!P) {
+        errs() << "CSInstrUse needs to be together with InstrUse";
+        return false;
+      }
+      P->CSAction = PGOOptions::CSIRUse;
+    }
+  }
+  if (TM)
+    TM->setPGOOption(P);
+
+  LoopAnalysisManager LAM;
+  FunctionAnalysisManager FAM;
+  CGSCCAnalysisManager CGAM;
+  ModuleAnalysisManager MAM;
+
+  PassInstrumentationCallbacks PIC;
+  PrintPassOptions PrintPassOpts;
+  PrintPassOpts.Verbose = DebugPM == DebugLogging::Verbose;
+  PrintPassOpts.SkipAnalyses = DebugPM == DebugLogging::Quiet;
+#if LLVM_VERSION_MAJOR >= 16
+  StandardInstrumentations SI(M.getContext(), DebugPM != DebugLogging::None,
+                              VerifyEachPass, PrintPassOpts);
+#else
+  StandardInstrumentations SI(DebugPM != DebugLogging::None, VerifyEachPass,
+                              PrintPassOpts);
+#endif
+  SI.registerCallbacks(PIC, &FAM);
+  DebugifyEachInstrumentation Debugify;
+  DebugifyStatsMap DIStatsMap;
+  DebugInfoPerPass DebugInfoBeforePass;
+  if (DebugifyEach) {
+    Debugify.setDIStatsMap(DIStatsMap);
+    Debugify.setDebugifyMode(DebugifyMode::SyntheticDebugInfo);
+    Debugify.registerCallbacks(PIC);
+  } else if (VerifyEachDebugInfoPreserve) {
+    Debugify.setDebugInfoBeforePass(DebugInfoBeforePass);
+    Debugify.setDebugifyMode(DebugifyMode::OriginalDebugInfo);
+    Debugify.setOrigDIVerifyBugsReportFilePath(VerifyDIPreserveExport);
+    Debugify.registerCallbacks(PIC);
+  }
+
+  PipelineTuningOptions PTO;
+  // LoopUnrolling defaults on to true and DisableLoopUnrolling is initialized
+  // to false above so we shouldn't necessarily need to check whether or not the
+  // option has been enabled.
+  PTO.LoopUnrolling = !DisableLoopUnrolling;
+  PassBuilder PB(TM, PTO, P, &PIC);
+  registerEPCallbacks(PB);
+
+  // For any loaded plugins, let them register pass builder callbacks.
+  for (auto &PassPlugin : PassPlugins)
+    PassPlugin.registerPassBuilderCallbacks(PB);
+
+#define HANDLE_EXTENSION(Ext)                                                  \
+  get##Ext##PluginInfo().RegisterPassBuilderCallbacks(PB);
+#include "llvm/Support/Extension.def"
+
+  // Specially handle the alias analysis manager so that we can register
+  // a custom pipeline of AA passes with it.
+  AAManager AA;
+  if (auto Err = PB.parseAAPipeline(AA, AAPipeline)) {
+    errs() << Arg0 << ": " << toString(std::move(Err)) << "\n";
+    return false;
+  }
+
+  // Register the AA manager first so that our version is the one used.
+  FAM.registerPass([&] { return std::move(AA); });
+  // Register our TargetLibraryInfoImpl.
+  FAM.registerPass([&] { return TargetLibraryAnalysis(*TLII); });
+
+  // Register all the basic analyses with the managers.
+  PB.registerModuleAnalyses(MAM);
+  PB.registerCGSCCAnalyses(CGAM);
+  PB.registerFunctionAnalyses(FAM);
+  PB.registerLoopAnalyses(LAM);
+  PB.crossRegisterProxies(LAM, FAM, CGAM, MAM);
+
+  ModulePassManager MPM;
+  if (EnableDebugify)
+    MPM.addPass(NewPMDebugifyPass());
+  if (VerifyDIPreserve)
+    MPM.addPass(NewPMDebugifyPass(DebugifyMode::OriginalDebugInfo, "",
+                                  &DebugInfoBeforePass));
+
+  // Add passes according to the -passes options.
+  if (!PassPipeline.empty()) {
+    if (auto Err = PB.parsePassPipeline(MPM, PassPipeline)) {
+      errs() << Arg0 << ": " << toString(std::move(Err)) << "\n";
+      return false;
+    }
+  }
+
+  if (VK > VK_NoVerifier)
+    MPM.addPass(VerifierPass());
+  if (EnableDebugify)
+    MPM.addPass(NewPMCheckDebugifyPass(false, "", &DIStatsMap));
+  if (VerifyDIPreserve)
+    MPM.addPass(NewPMCheckDebugifyPass(
+        false, "", nullptr, DebugifyMode::OriginalDebugInfo,
+        &DebugInfoBeforePass, VerifyDIPreserveExport));
+
+  // Add any relevant output pass at the end of the pipeline.
+  switch (OK) {
+  case OK_NoOutput:
+    break; // No output pass needed.
+  case OK_OutputAssembly:
+#if LLVM_VERSION_MAJOR >= 16
+    MPM.addPass(PrintModulePass(
+        Out->os(), "", ShouldPreserveAssemblyUseListOrder, EmitSummaryIndex));
+#endif
+    break;
+  case OK_OutputBitcode:
+    MPM.addPass(BitcodeWriterPass(Out->os(), ShouldPreserveBitcodeUseListOrder,
+                                  EmitSummaryIndex, EmitModuleHash));
+    break;
+  case OK_OutputThinLTOBitcode:
+    MPM.addPass(ThinLTOBitcodeWriterPass(
+        Out->os(), ThinLTOLinkOut ? &ThinLTOLinkOut->os() : nullptr));
+    break;
+  }
+
+  // Before executing passes, print the final values of the LLVM options.
+  cl::PrintOptionValues();
+
+  // Print a textual, '-passes=' compatible, representation of pipeline if
+  // requested.
+  if (PrintPipelinePasses) {
+    std::string Pipeline;
+    raw_string_ostream SOS(Pipeline);
+    MPM.printPipeline(SOS, [&PIC](StringRef ClassName) {
+      auto PassName = PIC.getPassNameForClassName(ClassName);
+      return PassName.empty() ? ClassName : PassName;
+    });
+    outs() << Pipeline;
+    outs() << "\n";
+
+    if (!DisablePipelineVerification) {
+      // Check that we can parse the returned pipeline string as an actual
+      // pipeline.
+      ModulePassManager TempPM;
+      if (auto Err = PB.parsePassPipeline(TempPM, Pipeline)) {
+        errs() << "Could not parse dumped pass pipeline: "
+               << toString(std::move(Err)) << "\n";
+        return false;
+      }
+    }
+
+    return true;
+  }
+
+  // Now that we have all of the passes ready, run them.
+  MPM.run(M, MAM);
+
+  // Declare success.
+  if (OK != OK_NoOutput) {
+    Out->keep();
+    if (OK == OK_OutputThinLTOBitcode && ThinLTOLinkOut)
+      ThinLTOLinkOut->keep();
+  }
+
+  if (OptRemarkFile)
+    OptRemarkFile->keep();
+
+  if (DebugifyEach && !DebugifyExport.empty())
+    exportDebugifyStats(DebugifyExport, Debugify.getDebugifyStatsMap());
+
+  return true;
+}
+
+void llvm::printPasses(raw_ostream &OS) {
+  PassBuilder PB;
+  PB.printPassNames(OS);
+}

--- a/lib/CompilerImpl/JITCompiler.cpp
+++ b/lib/CompilerImpl/JITCompiler.cpp
@@ -406,6 +406,7 @@ JITCompiler::runOptimizer(const std::filesystem::path &src_IR,
         s_ostream.str() + "\n");
     return failureFileName;
   }
+
   // Enable testing of whole program devirtualization on this module by invoking
   // the facility for updating public visibility to linkage unit visibility when
   // specified by an internal option. This is normally done during LTO which is

--- a/lib/CompilerImpl/JITCompiler.cpp
+++ b/lib/CompilerImpl/JITCompiler.cpp
@@ -335,8 +335,7 @@ JITCompiler::runOptimizer(const std::filesystem::path &src_IR,
   }
   std::unique_ptr<ToolOutputFile> RemarksFile = std::move(*RemarksFileOrErr);
 
-// Figure out what stream we are supposed to write to...
-// EDIT: we move this section to the new pass manager
+// Selection of stream we are supposed to write to moved to the new pass manager
 
 // Load the input module....
 #if LLVM_VERSION_MAJOR < 16

--- a/lib/CompilerImpl/JITCompiler.cpp
+++ b/lib/CompilerImpl/JITCompiler.cpp
@@ -46,8 +46,8 @@
 #include "llvm/Support/Error.h"
 #include "llvm/Transforms/Utils/Cloning.h"
 
-#ifndef OPT_EXE_NAME
-#define OPT_EXE_NAME "opt"
+#ifndef OPT_EXE_FULLPATH
+#define OPT_EXE_FULLPATH "/bin/opt"
 #endif
 #include <iostream>
 #include <vector>
@@ -215,13 +215,12 @@ JITCompiler::generateIR(const std::vector<std::filesystem::path> &src,
  * Unfortunatly there is no driver for accessing easily `opt`, like there is
  * for clang.
  * Therefore, this method is just an adapted copy of the original `opt`.
+ * The error reporting had been changed, from llvm::errs() to report_error().
  * It supports all the options of `opt` but the ones related to output
  * management.
  * It is a constraint for this method to generate a well-formed output file.
  * If this method is not able to generate a well-formed optimized output file,
  * it will return an empty path string as generated failureFileName.
- *
- * This method only supports the legacy pass manager.
  */
 std::filesystem::path
 JITCompiler::runOptimizer(const std::filesystem::path &src_IR,
@@ -233,7 +232,7 @@ JITCompiler::runOptimizer(const std::filesystem::path &src_IR,
 
   // what we return when generateIR fails
   const std::filesystem::path failureFileName = "";
-
+  // Our custom error reporting function
   auto report_error = [&](const std::string message) {
     std::string error_string = "JITCompiler::runOptimizer";
     error_string = error_string + " ERROR during processing of version ";
@@ -243,305 +242,538 @@ JITCompiler::runOptimizer(const std::filesystem::path &src_IR,
     Compiler::log_string(error_string);
     return;
   };
-
-  llvm::LLVMContext optContext;
+  // Convert options to an argv-like array
   const std::vector<std::string> &argv_owner = getArgV(options);
-  const size_t argc = argv_owner.size() + 1; // opt <options>
-  std::vector<const char *> argv;
-  std::string log_str = std::filesystem::u8path(OPT_EXE_NAME).string();
+  const size_t argc = argv_owner.size() + 1; // opt <options>, +1 for opt
+  std::vector<const char *> argv;            // fake argv
+  // log the command line string used to create this task
+  std::string log_str = std::filesystem::u8path(OPT_EXE_FULLPATH).string();
   log_str += " ";
   argv.reserve(argc);
-  argv.push_back(std::move(std::filesystem::u8path(OPT_EXE_NAME).c_str()));
+  argv.push_back(std::move(
+      std::filesystem::u8path(OPT_EXE_FULLPATH).c_str())); // /bin/opt...
   for (const auto &arg : argv_owner) {
     argv.push_back(arg.c_str());
     log_str = log_str + arg + " ";
   }
-  Compiler::log_string(log_str);
+  // Equivalent command
+  log_str += src_IR.string() + " -o " + optBCfilename.c_str();
+  Compiler::log_string("JIT: " + log_str);
 
   // command line options are static and should be accessed exclusively
   opt_parse_mtx.lock();
-
+  // Clean old opt values
   resetOptOptions();
+  // Parse invoking params
   llvm::cl::ParseCommandLineOptions(argc,
                                     const_cast<const char **>(argv.data()),
                                     "JITCompiler::runOptimizer");
+  // Set input and output files, like if they had been parsed from the cli
+  InputFilename = src_IR.string();
+  OutputFilename = optBCfilename.string();
+  // parse plugins, this was done in opt.cpp in the main function.
+  // From now on, we can almost follow what is being done in opt.cpp
+  // By remembering to modify return values and error reporting accordingly.
+  llvm::SmallVector<llvm::PassPlugin, 1> PluginList;
+  PassPlugins.setCallback([&](const std::string &PluginPath) {
+    llvm::Expected<PassPlugin> Plugin = llvm::PassPlugin::Load(PluginPath);
+    if (!Plugin) {
+      report_error(" Failed to load passes from '" + PluginPath +
+                   "'. Request ignored.\n");
+      return;
+    }
+    PluginList.emplace_back(Plugin.get());
+  });
+  using namespace llvm;
+  // Prepare the context, in opt.cpp is simply Context
+  LLVMContext optContext;
+  // If `-passes=` is specified, use NPM (new pass manager).
+  // If `-enable-new-pm` is specified and there are no codegen passes, use NPM.
+  // e.g. `-enable-new-pm -sroa` will use NPM.
+  // but `-enable-new-pm -codegenprepare` will still revert to legacy PM.
+  const bool UseNPM = (EnableNewPassManager && !shouldForceLegacyPM()) ||
+                      PassPipeline.getNumOccurrences() > 0;
+  if (UseNPM && !PassList.empty()) {
+    report_error(
+        "The `opt -passname` syntax for the new pass manager is "
+        "not supported, please use `opt -passes=<pipeline>` (or the `-p` "
+        "alias for a more concise version).\nSee "
+        "https://llvm.org/docs/NewPassManager.html#invoking-opt "
+        "for more details on the pass pipeline syntax.\n\n");
+    return failureFileName;
+  }
+  if (!UseNPM && PluginList.size()) {
+    report_error(std::string(argv[0]) + ": " + PassPlugins.ArgStr.str() +
+                 " specified with legacy PM.\n");
+    return failureFileName;
+  }
+
+  TimeTracerRAII TimeTracer(argv[0]);
+
+  SMDiagnostic Err;
 
   optContext.setDiscardValueNames(DiscardValueNames);
   if (!DisableDITypeMap) {
     optContext.enableDebugTypeODRUniquing();
   }
 
-  // load llvm::Module
-  llvm::SMDiagnostic parsingInputErrorCode;
-  auto module =
-      llvm::parseIRFile(src_IR.string(), parsingInputErrorCode, optContext);
-  if (!module) {
+  Expected<std::unique_ptr<ToolOutputFile>> RemarksFileOrErr =
+      setupLLVMOptimizationRemarks(optContext, RemarksFilename, RemarksPasses,
+                                   RemarksFormat, RemarksWithHotness,
+                                   RemarksHotnessThreshold);
+  if (Error E = RemarksFileOrErr.takeError()) {
+    report_error("During optimization remarks, " + toString(std::move(E)) +
+                 '\n');
+    return failureFileName;
+  }
+  std::unique_ptr<ToolOutputFile> RemarksFile = std::move(*RemarksFileOrErr);
+
+// Figure out what stream we are supposed to write to...
+// EDIT: we move this section to the new pass manager
+
+// Load the input module....
+#if LLVM_VERSION_MAJOR < 16
+  // Load the input module...
+  auto SetDataLayout = [](StringRef) -> Optional<std::string> {
+    if (ClDataLayout.empty())
+      return None;
+    return ClDataLayout;
+  };
+#else
+  auto SetDataLayout = [](StringRef, StringRef) -> std::optional<std::string> {
+    if (ClDataLayout.empty())
+      return std::nullopt;
+    return ClDataLayout;
+  };
+#endif
+  // EDIT: injected our source file here
+  std::unique_ptr<llvm::Module> M;
+  if (NoUpgradeDebugInfo)
+    M = parseAssemblyFileWithIndexNoUpgradeDebugInfo(
+            InputFilename, Err, optContext, nullptr, SetDataLayout)
+            .Mod;
+  else
+#if LLVM_VERSION_MAJOR < 16
+    M = parseIRFile(InputFilename, Err, optContext, SetDataLayout);
+#else
+    M = parseIRFile(InputFilename, Err, optContext,
+                    llvm::ParserCallbacks(SetDataLayout));
+#endif
+  if (!M) {
     std::string parsing_error_str;
     llvm::raw_string_ostream s_ostream(parsing_error_str);
-    parsingInputErrorCode.print(argv[0], s_ostream);
+    Err.print(argv[0], s_ostream);
     report_error("Unable to load module from source file\n" + s_ostream.str());
     if (!Compiler::exists(src_IR)) {
-      report_error("Cannot find source file " + src_IR.string());
+      report_error("Cannot find source file " + src_IR.string() + "\n");
     }
     return failureFileName;
   }
 
   // Strip debug info before running the verifier.
   if (StripDebug) {
-    llvm::StripDebugInfo(*module);
+    llvm::StripDebugInfo(*M);
   }
+  // Erase module-level named metadata, if requested.
+  if (StripNamedMetadata) {
+    while (!M->named_metadata_empty()) {
+      NamedMDNode *NMD = &*M->named_metadata_begin();
+      M->eraseNamedMetadata(NMD);
+    }
+  }
+  // If we are supposed to override the target triple or data layout, do so now.
+  if (!TargetTriple.empty())
+    M->setTargetTriple(Triple::normalize(TargetTriple));
 
   // Immediately run the verifier to catch any problems before starting up the
   // pass pipelines.  Otherwise we can crash on broken code during
   // doInitialization().
-  if (!NoVerify && llvm::verifyModule(*module, &llvm::errs())) {
-    report_error("Verifier check fail: input module is broken!\n");
+  // EDIT: to have a stream
+  std::string parsing_error_str;
+  llvm::raw_string_ostream s_ostream(parsing_error_str);
+  if (!NoVerify && llvm::verifyModule(*M, &s_ostream)) {
+    report_error(
+        "Verifier check fail: input module is broken! Error details: " +
+        s_ostream.str() + "\n");
+    return failureFileName;
+  }
+  // Enable testing of whole program devirtualization on this module by invoking
+  // the facility for updating public visibility to linkage unit visibility when
+  // specified by an internal option. This is normally done during LTO which is
+  // not performed via opt.
+  updateVCallVisibilityInModule(*M,
+                                /* WholeProgramVisibilityEnabledInLTO */ false,
+                                /* DynamicExportSymbols */ {});
+  // Figure out what stream we are supposed to write to...
+  // EDIT: moved to NPM because it conflicts with the legacy PM
+  // retrieve module triple and prepare Target Machine object (may be empty)
+  llvm::Triple ModuleTriple(M->getTargetTriple());
+  std::string CPUStr, FeaturesStr;
+  llvm::TargetMachine *Machine = nullptr;
+  llvm::TargetOptions Options =
+      llvm::codegen::InitTargetOptionsFromCodeGenFlags(ModuleTriple);
+
+  if (ModuleTriple.getArch()) {
+    CPUStr = llvm::codegen::getCPUStr();
+    FeaturesStr = llvm::codegen::getFeaturesStr();
+    Machine = GetTargetMachine(ModuleTriple, CPUStr, FeaturesStr, Options);
+  } else if (ModuleTriple.getArchName() != "unknown" &&
+             ModuleTriple.getArchName() != "") {
+    report_error(std::string(argv[0]) + ": unrecognized architecture '" +
+                 ModuleTriple.getArchName().str() + "' provided.\n");
     return failureFileName;
   }
 
-  // If we are supposed to override the target triple, do so now.
-  if (!TargetTriple.empty()) {
-    module->setTargetTriple(llvm::Triple::normalize(TargetTriple));
-  }
-
-  // retrieve module triple and prepare Target Machine object (may be empty)
-  llvm::Triple moduleTriple(module->getTargetTriple());
-  std::string optCPUStr, optFeaturesStr;
-  llvm::TargetMachine *optTMachine = nullptr;
-  const llvm::TargetOptions Options =
-      llvm::codegen::InitTargetOptionsFromCodeGenFlags(moduleTriple);
-  // llvm static helper function
-  std::string lookupError;
-  if (moduleTriple.getArch()) {
-    optCPUStr = llvm::codegen::getCPUStr(); // llvm static helper function
-    optFeaturesStr =
-        llvm::codegen::getFeaturesStr(); // llvm static helper function
-  }
-  const llvm::Target *TheTarget = llvm::TargetRegistry::lookupTarget(
-      llvm::codegen::getMArch(), moduleTriple, lookupError);
-  // Some modules don't specify a triple, and this is okay.
-  if (!TheTarget) {
-    optTMachine = nullptr;
-  } else {
-    optTMachine = TheTarget->createTargetMachine(
-        moduleTriple.getTriple(), optCPUStr, optFeaturesStr, Options,
-        llvm::codegen::getRelocModel(),
-        llvm::CodeModel::Small, // llvm::codegen::getCodeModel returns zero
-                                // (casted to Tiny), which is wrong! Going with
-                                // small which is the default model for majority
-                                // of supported targets
-        GetCodeGenOptLevel());
-  }
-  std::unique_ptr<llvm::TargetMachine> actualTM(optTMachine);
+  std::unique_ptr<TargetMachine> TM(Machine);
   // Override function attributes based on CPUStr, FeaturesStr,
   // and command line flags.
-  llvm::codegen::setFunctionAttributes(optCPUStr, optFeaturesStr, *module);
+  llvm::codegen::setFunctionAttributes(CPUStr, FeaturesStr, *M);
 
-  // Create a PassManager to hold and optimize the collection of passes we are
-  // about to build.
-  llvm::legacy::PassManager Passes;
+  // If the output is set to be emitted to standard out, and standard out is a
+  // console, print out a warning message and refuse to do it.  We don't
+  // impress anyone by spewing tons of binary goo to a terminal.
+  // EDIT: Moved in NPM
+  if (OutputThinLTOBC)
+    M->addModuleFlag(llvm::Module::Error, "EnableSplitLTOUnit", SplitLTOUnit);
 
   // Add an appropriate TargetLibraryInfo pass for the module's triple.
-  llvm::TargetLibraryInfoImpl TLII(moduleTriple);
+  llvm::TargetLibraryInfoImpl TLII(ModuleTriple);
 
   // The -disable-simplify-libcalls flag actually disables all builtin optzns.
   if (DisableSimplifyLibCalls) {
     TLII.disableAllFunctions();
-  }
-  Passes.add(new llvm::TargetLibraryInfoWrapperPass(TLII));
-
-  // Add an appropriate DataLayout instance for this module.
-  const llvm::DataLayout &DL = module->getDataLayout();
-  if (DL.isDefault() && !DefaultDataLayout.empty()) {
-    module->setDataLayout(DefaultDataLayout);
-  }
-
-  // Add internal analysis passes from the target machine.
-  Passes.add(llvm::createTargetTransformInfoWrapperPass(
-      (actualTM) ? actualTM->getTargetIRAnalysis() : llvm::TargetIRAnalysis()));
-
-  std::unique_ptr<llvm::legacy::FunctionPassManager> FPasses;
-  if (OptLevelO0 || OptLevelO1 || OptLevelO2 || OptLevelOs || OptLevelOz ||
-      OptLevelO3) {
-    FPasses.reset(new llvm::legacy::FunctionPassManager(module.get()));
-    FPasses->add(llvm::createTargetTransformInfoWrapperPass(
-        actualTM ? actualTM->getTargetIRAnalysis() : llvm::TargetIRAnalysis()));
+  } else {
+    // Disable individual builtin functions in TargetLibraryInfo.
+    llvm::LibFunc F;
+    for (auto &FuncName : DisableBuiltins)
+      if (TLII.getLibFunc(FuncName, F))
+        TLII.setUnavailable(F);
+      else {
+        report_error(std::string(argv[0]) +
+                     ": cannot disable nonexistent builtin function " +
+                     FuncName + '\n');
+        return failureFileName;
+      }
   }
 
-  // Create a new optimization pass for each one specified on the command line
-  for (uint64_t i = 0; i < PassList.size(); ++i) {
-    if (StandardLinkOpts &&
-        StandardLinkOpts.getPosition() < PassList.getPosition(i)) {
+  // Use legacy pass manager, default in LLVM 15 and lower
+  // Legacy PM implementation (Out variable name had been replaced to avoid
+  // confusion)
+  // --------------------------------------------------------------------------------------------
+  if (!UseNPM) {
+    // Create a PassManager to hold and optimize the collection of passes we are
+    // about to build.
+    llvm::legacy::PassManager Passes;
+
+    Passes.add(new llvm::TargetLibraryInfoWrapperPass(TLII));
+
+    // Add an appropriate DataLayout instance for this module.
+    const llvm::DataLayout &DL = M->getDataLayout();
+    if (DL.isDefault() && !ClDataLayout.empty()) {
+      M->setDataLayout(ClDataLayout);
+    }
+
+    // Add internal analysis passes from the target machine.
+    Passes.add(llvm::createTargetTransformInfoWrapperPass(
+        (TM) ? TM->getTargetIRAnalysis() : llvm::TargetIRAnalysis()));
+
+    std::unique_ptr<llvm::legacy::FunctionPassManager> FPasses;
+    if (OptLevelO0 || OptLevelO1 || OptLevelO2 || OptLevelOs || OptLevelOz ||
+        OptLevelO3) {
+      FPasses.reset(new llvm::legacy::FunctionPassManager(M.get()));
+      FPasses->add(llvm::createTargetTransformInfoWrapperPass(
+          TM ? TM->getTargetIRAnalysis() : llvm::TargetIRAnalysis()));
+    }
+
+    // Create a new optimization pass for each one specified on the command line
+    for (uint64_t i = 0; i < PassList.size(); ++i) {
+      if (StandardLinkOpts &&
+          StandardLinkOpts.getPosition() < PassList.getPosition(i)) {
+        AddStandardLinkPasses(Passes);
+        StandardLinkOpts = false;
+      }
+      if (OptLevelO0 && OptLevelO0.getPosition() < PassList.getPosition(i)) {
+        AddOptimizationPasses(Passes, *FPasses, TM.get(), 0, 0);
+        OptLevelO0 = false;
+      }
+      if (OptLevelO1 && OptLevelO1.getPosition() < PassList.getPosition(i)) {
+        AddOptimizationPasses(Passes, *FPasses, TM.get(), 1, 0);
+        OptLevelO1 = false;
+      }
+      if (OptLevelO2 && OptLevelO2.getPosition() < PassList.getPosition(i)) {
+        AddOptimizationPasses(Passes, *FPasses, TM.get(), 2, 0);
+        OptLevelO2 = false;
+      }
+      if (OptLevelOs && OptLevelOs.getPosition() < PassList.getPosition(i)) {
+        AddOptimizationPasses(Passes, *FPasses, TM.get(), 2, 1);
+        OptLevelOs = false;
+      }
+      if (OptLevelOz && OptLevelOz.getPosition() < PassList.getPosition(i)) {
+        AddOptimizationPasses(Passes, *FPasses, TM.get(), 2, 2);
+        OptLevelOz = false;
+      }
+      if (OptLevelO3 && OptLevelO3.getPosition() < PassList.getPosition(i)) {
+        AddOptimizationPasses(Passes, *FPasses, TM.get(), 3, 0);
+        OptLevelO3 = false;
+      }
+
+      const llvm::PassInfo *PassInf = PassList[i];
+      llvm::Pass *P = nullptr;
+      if (PassInf->getNormalCtor()) {
+        P = PassInf->getNormalCtor()();
+      } else {
+        report_error("Cannot create pass: " +
+                     std::string(PassInf->getPassName()));
+      }
+      if (P) {
+        auto Kind = P->getPassKind();
+        addPass(Passes, P);
+      }
+    } // end for each pass in PassList
+
+    // now add standard presets of optimization passes
+    if (StandardLinkOpts) {
       AddStandardLinkPasses(Passes);
       StandardLinkOpts = false;
     }
-    if (OptLevelO0 && OptLevelO0.getPosition() < PassList.getPosition(i)) {
-      AddOptimizationPasses(Passes, *FPasses, actualTM.get(), 0, 0);
-      OptLevelO0 = false;
+    if (OptLevelO0) {
+      AddOptimizationPasses(Passes, *FPasses, TM.get(), 0, 0);
     }
-    if (OptLevelO1 && OptLevelO1.getPosition() < PassList.getPosition(i)) {
-      AddOptimizationPasses(Passes, *FPasses, actualTM.get(), 1, 0);
-      OptLevelO1 = false;
+    if (OptLevelO1) {
+      AddOptimizationPasses(Passes, *FPasses, TM.get(), 1, 0);
     }
-    if (OptLevelO2 && OptLevelO2.getPosition() < PassList.getPosition(i)) {
-      AddOptimizationPasses(Passes, *FPasses, actualTM.get(), 2, 0);
-      OptLevelO2 = false;
+    if (OptLevelO2) {
+      AddOptimizationPasses(Passes, *FPasses, TM.get(), 2, 0);
     }
-    if (OptLevelOs && OptLevelOs.getPosition() < PassList.getPosition(i)) {
-      AddOptimizationPasses(Passes, *FPasses, actualTM.get(), 2, 1);
-      OptLevelOs = false;
+    if (OptLevelOs) {
+      AddOptimizationPasses(Passes, *FPasses, TM.get(), 2, 1);
     }
-    if (OptLevelOz && OptLevelOz.getPosition() < PassList.getPosition(i)) {
-      AddOptimizationPasses(Passes, *FPasses, actualTM.get(), 2, 2);
-      OptLevelOz = false;
+    if (OptLevelOz) {
+      AddOptimizationPasses(Passes, *FPasses, TM.get(), 2, 2);
     }
-    if (OptLevelO3 && OptLevelO3.getPosition() < PassList.getPosition(i)) {
-      AddOptimizationPasses(Passes, *FPasses, actualTM.get(), 3, 0);
-      OptLevelO3 = false;
+    if (OptLevelO3) {
+      AddOptimizationPasses(Passes, *FPasses, TM.get(), 3, 0);
     }
 
-    const llvm::PassInfo *PassInf = PassList[i];
-    llvm::Pass *P = nullptr;
-    if (PassInf->getNormalCtor()) {
-      P = PassInf->getNormalCtor()();
+    // run function passes
+    if (FPasses) {
+      FPasses->doInitialization();
+      for (llvm::Function &F : *M) {
+        FPasses->run(F);
+      }
+      FPasses->doFinalization();
+    }
+
+    // Check that the module is well formed on completion of optimization
+    if (!NoVerify && !VerifyEach) {
+      Passes.add(llvm::createVerifierPass());
+    }
+    std::error_code outFileCreationErrorCode;
+    std::unique_ptr<llvm::ToolOutputFile> Out =
+        std::make_unique<llvm::ToolOutputFile>(optBCfilename.c_str(),
+                                               outFileCreationErrorCode,
+                                               llvm::sys::fs::OF_None);
+    if (!Out) {
+      report_error("Could not create output file");
+      return failureFileName;
+    }
+
+    // In run twice mode, we want to make sure the output is bit-by-bit
+    // equivalent if we run the pass manager again, so setup two buffers and
+    // a stream to write to them.
+    llvm::SmallVector<char, 0> Buffer;
+    llvm::SmallVector<char, 0> CompileTwiceBuffer;
+    std::unique_ptr<llvm::raw_svector_ostream> BOS;
+    llvm::raw_ostream *OS = nullptr;
+
+    // Write bitcode or assembly to the output as the last step...
+    OS = &Out->os();
+    if (RunTwice) {
+      BOS = std::make_unique<llvm::raw_svector_ostream>(Buffer);
+      OS = BOS.get();
+    }
+    if (OutputAssembly) {
+      if (EmitSummaryIndex) {
+        report_error("Text output is incompatible with -module-summary");
+      }
+      if (EmitModuleHash) {
+        report_error("Text output is incompatible with -module-hash");
+      }
+      Passes.add(createPrintModulePass(*OS, "", PreserveAssemblyUseListOrder));
+    }
+#if LLVM_VERSION_MAJOR < 16
+    else if (OutputThinLTOBC) {
+      Passes.add(createWriteThinLTOBitcodePass(*OS));
+    }
+#endif
+    else {
+      Passes.add(createBitcodeWriterPass(*OS, PreserveBitcodeUseListOrder,
+                                         EmitSummaryIndex, EmitModuleHash));
+    }
+
+    // #ifdef VC_DEBUG
+    //  Before executing passes, print the final values of the LLVM options.
+    llvm::cl::PrintOptionValues();
+    // #endif
+
+    // If requested, run all passes again with the same pass manager to catch
+    // bugs caused by persistent state in the passes
+    if (RunTwice) {
+      std::unique_ptr<llvm::Module> module2(llvm::CloneModule(*M));
+      Passes.run(*module2);
+      CompileTwiceBuffer = Buffer;
+      Buffer.clear();
+    }
+
+    // Now that we have all of the passes ready, run them.
+    Passes.run(*M);
+
+    // Compare the two outputs and make sure they're the same
+    if (RunTwice) {
+      if (Buffer.size() != CompileTwiceBuffer.size() ||
+          (memcmp(Buffer.data(), CompileTwiceBuffer.data(), Buffer.size()) !=
+           0)) {
+        // running twice the same passes generated diverging bitcode versions
+        const std::string error_message =
+            "Running the pass manager twice changed the output.\n"
+            "Writing the result of the second run to the specified output.\n"
+            "To generate the one-run comparison binary, just run without\n"
+            "the compile-twice option\n";
+        report_error(error_message);
+        Out->os() << BOS->str();
+        Out->keep();
+        if (Compiler::exists(optBCfilename)) {
+          return optBCfilename;
+        }
+        return failureFileName;
+      } // end if divengent bitcodes
+      Out->os() << BOS->str();
+    }
+
+    opt_parse_mtx.unlock();
+
+    // Declare success.
+    Out->keep();
+    if (Compiler::exists(optBCfilename)) {
+      return optBCfilename;
+    }
+    report_error(
+        "Unexpected error: Opt succeded but optBCfilename does not exist");
+    return failureFileName;
+  } else if (LLVM_VERSION_MAJOR >= 16) {
+    // New PM implementation
+    // --------------------------------------------------------------------------------------------
+    // Use the new pass manager.
+    // Figure out what stream we are supposed to write to...
+    // EDIT: It conflicts with the old PM implementation, so we implement it
+    // here
+    std::unique_ptr<ToolOutputFile> Out;
+    std::unique_ptr<ToolOutputFile> ThinLinkOut;
+    if (NoOutput) {
+      if (!OutputFilename.empty())
+        report_error(
+            "WARNING: The -o (output filename) option is ignored when\n"
+            "the --disable-output option is used.\n");
     } else {
-      report_error("Cannot create pass: " +
-                   std::string(PassInf->getPassName()));
+      // Default to standard output. EDIT: this should never happen, as we set
+      // the OutputFilename regardless
+      if (OutputFilename.empty())
+        OutputFilename = "-";
+      std::error_code EC;
+      sys::fs::OpenFlags Flags =
+          OutputAssembly ? sys::fs::OF_TextWithCRLF : sys::fs::OF_None;
+      Out.reset(new ToolOutputFile(OutputFilename, EC, Flags));
+      if (EC) {
+        report_error(EC.message() + '\n');
+        return failureFileName;
+      }
+      if (!ThinLinkBitcodeFile.empty()) {
+        ThinLinkOut.reset(
+            new ToolOutputFile(ThinLinkBitcodeFile, EC, sys::fs::OF_None));
+        if (EC) {
+          report_error(EC.message() + '\n');
+          return failureFileName;
+        }
+      }
     }
-    if (P) {
-      auto Kind = P->getPassKind();
-      addPass(Passes, P);
+    // EDIT: moved due to Out defined afterwards
+    // If the output is set to be emitted to standard out, and standard out is a
+    // console, print out a warning message and refuse to do it.  We don't
+    // impress anyone by spewing tons of binary goo to a terminal.
+    if (!Force && !NoOutput && !OutputAssembly)
+      if (CheckBitcodeOutputToConsole(Out->os()))
+        NoOutput = true;
+    // EDIT: now this section should be identical to the one in opt.cpp
+    if (legacy::debugPassSpecified()) {
+      report_error(
+          "-debug-pass does not work with the new PM, either use "
+          "-debug-pass-manager, or use the legacy PM (-enable-new-pm=0)\n");
+      return failureFileName;
     }
-  } // end for each pass in PassList
-
-  // now add standard presets of optimization passes
-  if (StandardLinkOpts) {
-    AddStandardLinkPasses(Passes);
-    StandardLinkOpts = false;
-  }
-  if (OptLevelO0) {
-    AddOptimizationPasses(Passes, *FPasses, actualTM.get(), 0, 0);
-  }
-  if (OptLevelO1) {
-    AddOptimizationPasses(Passes, *FPasses, actualTM.get(), 1, 0);
-  }
-  if (OptLevelO2) {
-    AddOptimizationPasses(Passes, *FPasses, actualTM.get(), 2, 0);
-  }
-  if (OptLevelOs) {
-    AddOptimizationPasses(Passes, *FPasses, actualTM.get(), 2, 1);
-  }
-  if (OptLevelOz) {
-    AddOptimizationPasses(Passes, *FPasses, actualTM.get(), 2, 2);
-  }
-  if (OptLevelO3) {
-    AddOptimizationPasses(Passes, *FPasses, actualTM.get(), 3, 0);
-  }
-
-  // run function passes
-  if (FPasses) {
-    FPasses->doInitialization();
-    for (llvm::Function &F : *module) {
-      FPasses->run(F);
+    auto NumOLevel = OptLevelO0 + OptLevelO1 + OptLevelO2 + OptLevelO3 +
+                     OptLevelOs + OptLevelOz;
+    if (NumOLevel > 1) {
+      report_error("Cannot specify multiple -O#\n");
+      return failureFileName;
     }
-    FPasses->doFinalization();
-  }
+    if (NumOLevel > 0 && (PassPipeline.getNumOccurrences() > 0)) {
+      report_error("Cannot specify -O# and --passes=/--foo-pass, use "
+                   "-passes='default<O#>,other-pass'\n");
+      return failureFileName;
+    }
+    std::string Pipeline = PassPipeline;
 
-  // Check that the module is well formed on completion of optimization
-  if (!NoVerify && !VerifyEach) {
-    Passes.add(llvm::createVerifierPass());
-  }
+    if (OptLevelO0)
+      Pipeline = "default<O0>";
+    if (OptLevelO1)
+      Pipeline = "default<O1>";
+    if (OptLevelO2)
+      Pipeline = "default<O2>";
+    if (OptLevelO3)
+      Pipeline = "default<O3>";
+    if (OptLevelOs)
+      Pipeline = "default<Os>";
+    if (OptLevelOz)
+      Pipeline = "default<Oz>";
+    opt_tool::OutputKind OK = opt_tool::OK_NoOutput;
+    // if (!opt_tool::NoOutput)
+    OK = OutputAssembly ? opt_tool::OK_OutputAssembly
+                        : (OutputThinLTOBC ? opt_tool::OK_OutputThinLTOBitcode
+                                           : opt_tool::OK_OutputBitcode);
 
-  std::error_code outFileCreationErrorCode;
-  std::unique_ptr<llvm::ToolOutputFile> Out =
-      std::make_unique<llvm::ToolOutputFile>(optBCfilename.c_str(),
-                                             outFileCreationErrorCode,
-                                             llvm::sys::fs::OF_None);
-  if (!Out) {
-    report_error("Could not create output file");
+    opt_tool::VerifierKind VK = opt_tool::VK_VerifyOut;
+    if (NoVerify)
+      VK = opt_tool::VK_NoVerifier;
+    else if (VerifyEach)
+      VK = opt_tool::VK_VerifyEachPass;
+
+    // The user has asked to use the new pass manager and provided a pipeline
+    // string. Hand off the rest of the functionality to the new code for that
+    // layer.
+    auto ok = runPassPipeline(argv[0], *M, TM.get(), &TLII, Out.get(),
+                              ThinLinkOut.get(), RemarksFile.get(), Pipeline,
+                              PluginList, OK, VK, PreserveAssemblyUseListOrder,
+                              PreserveBitcodeUseListOrder, EmitSummaryIndex,
+                              EmitModuleHash, EnableDebugify,
+                              VerifyDebugInfoPreserve);
+    if (ok) {
+      if (exists(optBCfilename))
+        return optBCfilename;
+      else {
+        report_error(optBCfilename.string() +
+                     " should exist because opt succeded but it does not.");
+        return failureFileName;
+      }
+    } else {
+      return failureFileName;
+    }
+  } else {
+    const std::string error_message =
+        "The new pass manager implementation for LLVM 15 or less is not "
+        "implemented yet in libVersioningCompiler.";
+    report_error(error_message);
     return failureFileName;
   }
-
-  // In run twice mode, we want to make sure the output is bit-by-bit
-  // equivalent if we run the pass manager again, so setup two buffers and
-  // a stream to write to them.
-  llvm::SmallVector<char, 0> Buffer;
-  llvm::SmallVector<char, 0> CompileTwiceBuffer;
-  std::unique_ptr<llvm::raw_svector_ostream> BOS;
-  llvm::raw_ostream *OS = nullptr;
-
-  // Write bitcode or assembly to the output as the last step...
-  OS = &Out->os();
-  if (RunTwice) {
-    BOS = std::make_unique<llvm::raw_svector_ostream>(Buffer);
-    OS = BOS.get();
-  }
-  if (OutputAssembly) {
-    if (EmitSummaryIndex) {
-      report_error("Text output is incompatible with -module-summary");
-    }
-    if (EmitModuleHash) {
-      report_error("Text output is incompatible with -module-hash");
-    }
-    Passes.add(createPrintModulePass(*OS, "", PreserveAssemblyUseListOrder));
-  }
-#if LLVM_VERSION_MAJOR < 16
-  else if (OutputThinLTOBC) {
-    Passes.add(createWriteThinLTOBitcodePass(*OS));
-  }
-#endif
-  else {
-    Passes.add(createBitcodeWriterPass(*OS, PreserveBitcodeUseListOrder,
-                                       EmitSummaryIndex, EmitModuleHash));
-  }
-
-#ifdef VC_DEBUG
-  // Before executing passes, print the final values of the LLVM options.
-  llvm::cl::PrintOptionValues();
-#endif
-
-  // If requested, run all passes again with the same pass manager to catch
-  // bugs caused by persistent state in the passes
-  if (RunTwice) {
-    std::unique_ptr<llvm::Module> module2(llvm::CloneModule(*module));
-    Passes.run(*module2);
-    CompileTwiceBuffer = Buffer;
-    Buffer.clear();
-  }
-
-  // Now that we have all of the passes ready, run them.
-  Passes.run(*module);
-
-  // Compare the two outputs and make sure they're the same
-  if (RunTwice) {
-    if (Buffer.size() != CompileTwiceBuffer.size() ||
-        (memcmp(Buffer.data(), CompileTwiceBuffer.data(), Buffer.size()) !=
-         0)) {
-      // running twice the same passes generated diverging bitcode versions
-      const std::string error_message =
-          "Running the pass manager twice changed the output.\n"
-          "Writing the result of the second run to the specified output.\n"
-          "To generate the one-run comparison binary, just run without\n"
-          "the compile-twice option\n";
-      report_error(error_message);
-      Out->os() << BOS->str();
-      Out->keep();
-      if (Compiler::exists(optBCfilename)) {
-        return optBCfilename;
-      }
-      return failureFileName;
-    } // end if divengent bitcodes
-    Out->os() << BOS->str();
-  }
-
-  opt_parse_mtx.unlock();
-
-  // Declare success.
-  Out->keep();
-  if (Compiler::exists(optBCfilename)) {
-    return optBCfilename;
-  }
-  return failureFileName;
 }
 
 // ---------------------------------------------------------------------------
@@ -549,8 +781,8 @@ JITCompiler::runOptimizer(const std::filesystem::path &src_IR,
 // ---------------------------------------------------------------------------
 /** addModule wrapper
  *
- * Makes the actual call to llvm CompileLayer addModule functions and saves the
- * JIT compilation results in the JITCompiler class state
+ * Makes the actual call to llvm CompileLayer addModule functions and saves
+ * the JIT compilation results in the JITCompiler class state
  */
 void JITCompiler::addModule(std::unique_ptr<llvm::Module> m,
                             const std::string &versionID) {
@@ -593,8 +825,8 @@ JITCompiler::findSymbol(const std::string Name, const std::string &versionID) {
 /** Symbol Loading
  *
  * This implementation looks for the version saved module and adds it to the
- * llvm CompileLayer. It later resolves the symbol and returns it to its caller.
- * This is the function which actually performs the JIT compilation
+ * llvm CompileLayer. It later resolves the symbol and returns it to its
+ * caller. This is the function which actually performs the JIT compilation
  */
 
 //  if (exists(bin)) {
@@ -628,7 +860,8 @@ JITCompiler::loadSymbols(const std::filesystem::path &bin,
 
   std::vector<void *> symbols = {};
 
-  // In JITCompiler implementation bin is used as a reference to our version ID
+  // In JITCompiler implementation bin is used as a reference to our version
+  // ID
   const std::string versionID = bin.string();
 
   auto mm_iterator = _modules_map.find(versionID);
@@ -723,10 +956,10 @@ void JITCompiler::releaseSymbol(void **handler) {
 // ---------------------------------------------------------------------------
 /** JIT Compile the llvm module
  *
- * This implementation parses a previously generated (and eventually optimized)
- * IR file elevating it to its in-memory representation. This module is then
- * saved in the JITCompiler class instance state to be later added (by the
- * loadSymbol method) to llvm's CompilerLayer
+ * This implementation parses a previously generated (and eventually
+ * optimized) IR file elevating it to its in-memory representation. This
+ * module is then saved in the JITCompiler class instance state to be later
+ * added (by the loadSymbol method) to llvm's CompilerLayer
  */
 std::filesystem::path
 JITCompiler::generateBin(const std::vector<std::filesystem::path> &src,
@@ -735,6 +968,12 @@ JITCompiler::generateBin(const std::vector<std::filesystem::path> &src,
                          const opt_list_t options) {
 
   // The source IR file name to JIT compile
+  if (src.size() == 0) {
+    std::string error_string = "JITCompiler::generateBin";
+    error_string = error_string + " ERROR - no source file provided";
+    Compiler::log_string(error_string);
+    return "";
+  }
   std::filesystem::path source = src[0]; // if contains IR then it's just one
                                          // element, otherwise will generate it
 
@@ -754,15 +993,8 @@ JITCompiler::generateBin(const std::vector<std::filesystem::path> &src,
   // IR optimized filename
   const std::filesystem::path llvmOPTIRfileName =
       Compiler::getOptBitcodeFileName(versionID);
+
   // If IR files were not generated, generate it now but don't optimize it
-  if (!exists(llvmOPTIRfileName) && !exists(llvmIRfileName)) {
-    Compiler::log_string("IR file not found, generating from source..");
-
-    source = generateIR(src, func, versionID, options);
-  }
-
-  // What we return when generateIR fails
-  const std::string failureName = "";
 
   auto report_error = [&](const std::string message) {
     std::string error_string = "JITCompiler::generateBin";
@@ -773,6 +1005,27 @@ JITCompiler::generateBin(const std::vector<std::filesystem::path> &src,
     Compiler::log_string(error_string);
     return;
   };
+  // What we return when generateIR fails
+  const std::string failureName = "";
+
+  if (!exists(llvmOPTIRfileName) && !exists(llvmIRfileName)) {
+    Compiler::log_string("IR file not found, generating from source..");
+
+    source = generateIR(src, func, versionID, options);
+    if (source == failureName) {
+      report_error("Failed to generate version " + versionID +
+                   ": generateIR file not produced.");
+      return failureName;
+    } else if (!exists(source)) {
+      report_error("Failed to generate version " + versionID +
+                   ": generateIR file not found, this should not happen.");
+      return failureName;
+    }
+  } else if (!exists(source)) {
+    report_error("Cannot load module in version " + versionID +
+                 ": the source file " + source.string() + " does not exist.");
+    return failureName;
+  }
 
   llvm::SMDiagnostic parsing_input_error_code;
   Compiler::log_string("Jitting IR file: " + source.string());
@@ -780,8 +1033,9 @@ JITCompiler::generateBin(const std::vector<std::filesystem::path> &src,
   _modules_map[versionID] = std::move(llvm::parseIRFile(
       source.string(), parsing_input_error_code, *(_tsctx.getContext())));
   if (parsing_input_error_code.getMessage().str().length() > 0) {
-    report_error("Module was not generated: " +
-                 parsing_input_error_code.getMessage().str());
+    report_error(
+        "Module with source '" + source.string() +
+        "' was not generated: " + parsing_input_error_code.getMessage().str());
     return failureName;
   }
   return versionID;
@@ -799,7 +1053,8 @@ inline std::string JITCompiler::getOptionString(const Option &o) const {
   // remove single and double quotes
   std::string tmp_val = o.getValue();
   if (tmp_val.length() > 1 &&
-      (tmp_val[0] == '\"' && tmp_val[tmp_val.length() - 1] == '\"')) {
+      ((tmp_val[0] == '\"' && tmp_val[tmp_val.length() - 1] == '\"') ||
+       (tmp_val[0] == '\'' && tmp_val[tmp_val.length() - 1] == '\''))) {
     tmp_val = tmp_val.substr(1, tmp_val.length() - 2);
   }
   return o.getPrefix() + tmp_val;

--- a/lib/CompilerImpl/JITCompiler.cpp
+++ b/lib/CompilerImpl/JITCompiler.cpp
@@ -622,7 +622,7 @@ JITCompiler::runOptimizer(const std::filesystem::path &src_IR,
     }
 
     // #ifdef VC_DEBUG
-    //  Before executing passes, print the final values of the LLVM options.
+    // Before executing passes, print the final values of the LLVM options.
     llvm::cl::PrintOptionValues();
     // #endif
 

--- a/lib/CompilerImpl/JITCompiler.cpp
+++ b/lib/CompilerImpl/JITCompiler.cpp
@@ -262,15 +262,19 @@ JITCompiler::runOptimizer(const std::filesystem::path &src_IR,
 
   // command line options are static and should be accessed exclusively
   opt_parse_mtx.lock();
+
   // Clean old opt values
   resetOptOptions();
+  
   // Parse invoking params
   llvm::cl::ParseCommandLineOptions(argc,
                                     const_cast<const char **>(argv.data()),
                                     "JITCompiler::runOptimizer");
+
   // Set input and output files, like if they had been parsed from the cli
   InputFilename = src_IR.string();
   OutputFilename = optBCfilename.string();
+  
   // parse plugins, this was done in opt.cpp in the main function.
   // From now on, we can almost follow what is being done in opt.cpp
   // By remembering to modify return values and error reporting accordingly.
@@ -284,9 +288,12 @@ JITCompiler::runOptimizer(const std::filesystem::path &src_IR,
     }
     PluginList.emplace_back(Plugin.get());
   });
+
   using namespace llvm;
+
   // Prepare the context, in opt.cpp is simply Context
   LLVMContext optContext;
+  
   // If `-passes=` is specified, use NPM (new pass manager).
   // If `-enable-new-pm` is specified and there are no codegen passes, use NPM.
   // e.g. `-enable-new-pm -sroa` will use NPM.

--- a/lib/CompilerImpl/JITCompiler.cpp
+++ b/lib/CompilerImpl/JITCompiler.cpp
@@ -365,6 +365,7 @@ JITCompiler::runOptimizer(const std::filesystem::path &src_IR,
     M = parseIRFile(InputFilename, Err, optContext,
                     llvm::ParserCallbacks(SetDataLayout));
 #endif
+
   if (!M) {
     std::string parsing_error_str;
     llvm::raw_string_ostream s_ostream(parsing_error_str);
@@ -380,6 +381,7 @@ JITCompiler::runOptimizer(const std::filesystem::path &src_IR,
   if (StripDebug) {
     llvm::StripDebugInfo(*M);
   }
+
   // Erase module-level named metadata, if requested.
   if (StripNamedMetadata) {
     while (!M->named_metadata_empty()) {
@@ -387,6 +389,7 @@ JITCompiler::runOptimizer(const std::filesystem::path &src_IR,
       M->eraseNamedMetadata(NMD);
     }
   }
+
   // If we are supposed to override the target triple or data layout, do so now.
   if (!TargetTriple.empty())
     M->setTargetTriple(Triple::normalize(TargetTriple));


### PR DESCRIPTION
It is based on the previous work to port to LLVM15. It finally does the migration to the new pass manager in a maintainable way (edits from original LLVM files are highlighted). It is thought for LLVM 16